### PR TITLE
Fix feature check

### DIFF
--- a/citeproc.js
+++ b/citeproc.js
@@ -22,7 +22,7 @@
  *     this program.  If not, see <https://opensource.org/licenses/> or
  *     <http://www.gnu.org/licenses/> respectively.
  */
-if (!Array.indexOf) {
+if (!Array.prototype.hasOwnProperty('indexOf')) {
     Array.prototype.indexOf = function (obj) {
         var i, len;
         for (i = 0, len = this.length; i < len; i += 1) {


### PR DESCRIPTION
Currently, the indexOf feature check always evaluates to true (which resets the array prototype). 

This fixes that.

If you'd like to do one better, completely remove this feature check since now it exists in all browsers. (except IE < 9). Up to you