### PR TITLE
Workaround using reserved names as property names

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -144,7 +144,7 @@ CSL.Engine = function (sys, style, lang, forceLang) {
     this.setStyleAttributes();
 
     this.opt.xclass = this.cslXml.getAttributeValue(this.cslXml.dataObj, "class");
-    this.opt.class = this.opt.xclass;
+    this.opt["class"] = this.opt.xclass;
     this.opt.styleID = this.cslXml.getStyleId(this.cslXml.dataObj);
     if (CSL.setSuppressedJurisdictions) {
         CSL.setSuppressedJurisdictions(this.opt.styleID, this.opt.suppressedJurisdictions);

--- a/src/node_group.js
+++ b/src/node_group.js
@@ -226,9 +226,9 @@ CSL.Node.group = {
                 target.push(text_node);
 
                 var if_end = new CSL.Token("if", CSL.END);
-                CSL.Node.if.build.call(if_end, state, target);
+                CSL.Node["if"].build.call(if_end, state, target);
                 var else_start = new CSL.Token("else", CSL.START);
-                CSL.Node.else.build.call(else_start, state, target);
+                CSL.Node["else"].build.call(else_start, state, target);
             }
         }
 
@@ -301,7 +301,7 @@ CSL.Node.group = {
             
             if (this.juris) {
                 var else_end = new CSL.Token("else", CSL.END);
-                CSL.Node.else.build.call(else_end, state, target);
+                CSL.Node["else"].build.call(else_end, state, target);
                 var choose_end = new CSL.Token("choose", CSL.END);
                 CSL.Node.choose.build.call(choose_end, state, target);
             }


### PR DESCRIPTION
YUI Compressor complains if reserved names are used to identify
properties using dot syntax. Specify properties 'if', 'else', and
'class' using square bracket syntax.
