### PR TITLE
Switch DOI format to latest recommendation

### DIFF
--- a/src/formats.js
+++ b/src/formats.js
@@ -137,7 +137,7 @@ CSL.Output.Formats.prototype.html = {
         return "<a href=\"" + str + "\">" + str + "</a>";
     },
     "@DOI/true": function (state, str) {
-        return "<a href=\"http://dx.doi.org/" + str + "\">" + str + "</a>";
+        return "<a href=\"https://doi.org/" + str + "\">" + str + "</a>";
     }
 };
 
@@ -341,7 +341,7 @@ CSL.Output.Formats.prototype.rtf = {
         return "\\field{\\*\\fldinst{HYPERLINK \"" + str + "\"}}{\\fldrslt{"+ str +"}}";
     },
     "@DOI/true": function (state, str) {
-        return "\\field{\\*\\fldinst{HYPERLINK \"http://dx.doi.org/" + str + "\"}}{\\fldrslt{"+ str +"}}";
+        return "\\field{\\*\\fldinst{HYPERLINK \"https://doi.org/" + str + "\"}}{\\fldrslt{"+ str +"}}";
     }
 */
 


### PR DESCRIPTION
@fbennett, in response to https://bitbucket.org/fbennett/citeproc-js/pull-requests/8/generate-secure-doi-links/diff (and https://www.zotero.org/support/kb/doi_in_apa).

See https://github.com/Juris-M/citeproc-js/search?utf8=%E2%9C%93&q=dx.doi (I wasn't sure whether I had to change the unit tests in this repo).