### PR TITLE
Remove all unnecessary files from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type" : "git",
     "url" : "https://github.com/juris-m/citeproc-js.git"
   },
+  "files": [
+    "citeproc_commonjs.js"
+  ],
   "author": "Michael McMillan <email@michaelmcmillan.net> (http://michaelmcmillan.net/)",
   "contributors": [
       "Frank Bennett <biercenator@gmail.com> (https://juris-m.github.io)"


### PR DESCRIPTION
This simply adds a `files` property to package.json that only exposes the `citeproc_commonjs.js` file to npm to prevent all unnecessary files from being packaged.