### PR TITLE
Fix unsafe assignment

### DIFF
--- a/src/api_cite.js
+++ b/src/api_cite.js
@@ -198,6 +198,9 @@ CSL.Engine.prototype.processCitationCluster = function (citation, citationsPre, 
     }
     var update_items = [];
     for (var i = 0, ilen = citationByIndex.length; i < ilen; i += 1) {
+        if (!citationByIndex[i].properties) {
+            citationByIndex[i].properties = {};
+        }
         citationByIndex[i].properties.index = i;
         for (j = 0, jlen = citationByIndex[i].sortedItems.length; j < jlen; j += 1) {
             item = citationByIndex[i].sortedItems[j];


### PR DESCRIPTION
This PR addresses a potentially problematic line of code that may or may not lead to bugs depending on the existence of an optional parameter.

In the [CSL JSON specification](https://github.com/citation-style-language/schema/blob/master/csl-citation.json#L89-L97) for type `Citation`, you'll notice that the `properties` field is not listed as a required field. Because of that, it would be safer to check for the existence of it first (and set it as an empty object) prior to attempting to set a child property of it.