### PR TITLE
Added a null/empty/undefined test before termtxt.slice

### DIFF
--- a/citeproc.js
+++ b/citeproc.js
@@ -921,7 +921,7 @@ var CSL = {
                 }
             }
         } else {
-            if (termtxt.slice(-1).match(/[0-9]/)) {
+            if (termtxt && termtxt.slice(-1).match(/[0-9]/)) {
                 state.tmp.just_did_number = true;
             } else {
                 state.tmp.just_did_number = false;

--- a/citeproc_commonjs.js
+++ b/citeproc_commonjs.js
@@ -921,7 +921,7 @@ var CSL = {
                 }
             }
         } else {
-            if (termtxt.slice(-1).match(/[0-9]/)) {
+            if (termtxt && termtxt.slice(-1).match(/[0-9]/)) {
                 state.tmp.just_did_number = true;
             } else {
                 state.tmp.just_did_number = false;

--- a/citeproc_with_e4x.js
+++ b/citeproc_with_e4x.js
@@ -921,7 +921,7 @@ var CSL = {
                 }
             }
         } else {
-            if (termtxt.slice(-1).match(/[0-9]/)) {
+            if (termtxt && termtxt.slice(-1).match(/[0-9]/)) {
                 state.tmp.just_did_number = true;
             } else {
                 state.tmp.just_did_number = false;


### PR DESCRIPTION
Changed  `if(termtxt.slice(-1).match(/[0-9]/))` to `if(termtxt && termtxt.slice(-1).match(/[0-9]/))`

In some environments, failing to test for undefined/null/empty before doing the slice produces
an error, preventing the generation of some pub types (report, thesis) from some styles
(APA 6th edition, Glossa, Chicago 17th edition notes).

I encountered this problem while using citeproc-java (which in turn utilizes citeproc-js). I've attached the error message from citeproc-java. Line numbers differ slightly because citeproc-java uses an older version of citeproc.js.

[error-message.txt](https://github.com/Juris-M/citeproc-js/files/1461449/error-message.txt)