### PR TITLE
docs: use markdown format for the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-======
-README
-======
------------
-citeproc-js
------------
+# README
+
+## citeproc-js
 
 by Frank Bennett
 
@@ -11,7 +8,7 @@ This is a JavaScript implementation of the Citation Style Language
 (CSL). Since development began in 2009, citeproc-js has been deployed
 in numerous products and websites.
 
-Documentation is available on `ReadTheDocs <https://citeproc-js.readthedocs.org/en/latest/index.html>`_.
+Documentation is available on [ReadTheDocs](https://citeproc-js.readthedocs.org/en/latest/index.html).
 
 
 | 2016.03.08


### PR DESCRIPTION
npmjs.com can only parse and display markdown files.

Reference: https://github.com/npm/www/issues/42