### PR TITLE
Fix missing escape for `\end` in LaTeX format bibend

### DIFF
--- a/src/formats.js
+++ b/src/formats.js
@@ -580,7 +580,7 @@ CSL.Output.Formats.prototype.latex = {
         return text;
     },
     "bibstart": "\\begin{thebibliography}{4}",
-    "bibend": "\end{thebibliography}",
+    "bibend": "\\end{thebibliography}",
     "@font-style/italic": "{\\em %%STRING%%}",
     "@font-style/oblique": false,
     "@font-style/normal": false,


### PR DESCRIPTION
There should be two backslashes to escape the backslash in `\end`, as there are two in all other LaTeX commands. The current version results in broken output after rendering.