### PR TITLE
Add space after left margin in plain-text output

### DIFF
--- a/src/formats.js
+++ b/src/formats.js
@@ -211,7 +211,7 @@ CSL.Output.Formats.prototype.text = {
         return "\n"+str;
     },
     "@display/left-margin": function (state, str) {
-        return str;
+        return str + " ";
     },
     "@display/right-inline": function (state, str) {
         return str;


### PR DESCRIPTION
See zotero/zotero#2633 and the discussion on the CSL list:

https://discourse.citationstyles.org/t/space-after-first-field-in-plain-text-mode-when-using-second-field-align/1762

This change is already rolled out in Zotero.