### PR TITLE
Avoid for...in to iterate through array

### DIFF
--- a/src/util_processor.js
+++ b/src/util_processor.js
@@ -102,13 +102,11 @@ CSL.setDecorations = function (state, attributes) {
     var ret, key, pos;
     // This applies a fixed processing sequence
     ret = [];
-    for (pos in CSL.FORMAT_KEY_SEQUENCE) {
-        if (true) {
-            var key = CSL.FORMAT_KEY_SEQUENCE[pos];
-            if (attributes[key]) {
-                ret.push([key, attributes[key]]);
-                delete attributes[key];
-            }
+    for (pos = 0; pos < CSL.FORMAT_KEY_SEQUENCE.length; pos++) {
+        var key = CSL.FORMAT_KEY_SEQUENCE[pos];
+        if (attributes[key]) {
+            ret.push([key, attributes[key]]);
+            delete attributes[key];
         }
     }
     return ret;


### PR DESCRIPTION
Using for...in to iterate through the CSL.FORMAT_KEY_SEQUENCE array breaks things if the Array.prototype has been modified to have additional methods / attrs
Also removed unnecessary "if (true) { ..." conditional

The for...in loop was causing mysterious crashes when using citeproc in conjunction with the Isomorphic SmartClient js framework