### PR TITLE
Add follow-language-name-order option

### DIFF
--- a/citeproc_commonjs.js
+++ b/citeproc_commonjs.js
@@ -5058,6 +5058,14 @@ CSL.Engine.prototype.setAutoVietnameseNamesOption = function (arg) {
     }
 };
 
+CSL.Engine.prototype.setFollowLanguageNameOrderOption = function (arg) {
+    if (arg) {
+        this.opt["follow-language-name-order"] = true;
+    } else {
+        this.opt["follow-language-name-order"] = false;
+    }
+};
+
 CSL.Engine.prototype.setAbbreviations = function (arg) {
     if (this.sys.setAbbreviations) {
         this.sys.setAbbreviations(arg);
@@ -6465,6 +6473,7 @@ CSL.Engine.Opt = function () {
     // suffixes we support in separate fields.
     this["parse-names"] = true;
     // this["auto-vietnamese-names"] = true;
+    this["follow-language-name-order"] = true;
 
     this.citation_number_slug = false;
     this.trigraph = "Aaaa00:AaAa00:AaAA00:AAAA00";
@@ -13752,7 +13761,7 @@ CSL.NameOutput.prototype._isRomanesque = function (name) {
         } else if (this.Item.language) {
             top_locale = this.Item.language.slice(0, 2);
         }
-        if (["ja", "zh"].indexOf(top_locale) > -1) {
+        if (this.state.opt['follow-language-name-order'] && ["ja", "zh"].indexOf(top_locale) > -1) {
             ret = 1;
         }
     }


### PR DESCRIPTION
The following is an example of a bibliography of an imaginary translated book from English to Japanese.

```json
[
  {
    "id": "morgan2023jiyu",
    "author": [
      { "family": "Morgan", "given": "Casey" },
      { "family": "Patrov", "given": "Alexei" }
    ],
    "citation-key": "morgan2023jiyu",
    "event-place": "東京",
    "issued": { "date-parts": [[2023]] },
    "language": "ja",
    "original-date": { "date-parts": [[2022]] },
    "original-publisher": "Global Academic Press",
    "original-publisher-place": "Chicago, IL",
    "original-title": "The Philosophy of Free Will",
    "publisher": "城南大学出版会",
    "publisher-place": "東京",
    "title": "自由意志の哲学",
    "translator": [{ "family": "鈴木", "given": "真紀" }],
    "type": "book"
  }
]
```

When I process the bibliography item with `citeproc-js` and [a CSL-M style](https://github.com/kotobuki/chicago-fullnote-bibliography-short-title-subsequent-ja-csl), `citeproc-js` produces citations as follows.

- `Note` Morgan Casey、Patrov Alexei『自由意志の哲学』訳：鈴木真紀（東京：城南大学出版会、2023）。〔*The Philosophy of Free Will* (Chicago, IL: Global Academic Press, 2022).〕
- `Bibliography entry` Morgan Casey、Patrov Alexei『自由意志の哲学』翻訳：鈴木真紀、東京：城南大学出版会、2023。〔*The Philosophy of Free Will* (Chicago, IL: Global Academic Press, 2022).〕

As far as I know, it's common to keep the name order in the original language for translated items in Japan, I propose adding `follow-language-name-order` option. Here is an example with `citeproc.setFollowLanguageNameOrderOption(false)`.

- `Note` Casey Morgan、Alexei Patrov『自由意志の哲学』訳：鈴木真紀（東京：城南大学出版会、2023）。〔*The Philosophy of Free Will* (Chicago, IL: Global Academic Press, 2022).〕
- `Bibliography entry` Morgan, Casey、Alexei Patrov『自由意志の哲学』翻訳：鈴木真紀、東京：城南大学出版会、2023。〔*The Philosophy of Free Will* (Chicago, IL: Global Academic Press, 2022).〕

I hope that this will make sense and be accepted as a pull request.