### PR TITLE
Fix small backtick typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ reports on the `citeproc-js GitHub tracker <https://github.com/juris-m/citeproc-
 Building the processor
 ----------------------
 
-The processor files `citeproc.js`` and ``citeproc_commonjs.js`` are built
+The processor files ``citeproc.js`` and ``citeproc_commonjs.js`` are built
 automatically when tests are run (see below).
 
 -------------


### PR DESCRIPTION
Fixes a little typo in the README. 

![CleanShot 2024-06-27 at 15 32 51@2x](https://github.com/Juris-M/citeproc-js/assets/1091559/748e5b35-a623-4b54-b140-cae3501cf4a8)
