### PR TITLE
fix incorrect license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "contributors": [
         "Frank Bennett <biercenator@gmail.com> (https://juris-m.github.io)"
     ],
-    "license": "CPAL-1.0 OR AGPL-1.0",
+    "license": "(CPAL-1.0 OR AGPL-3.0-or-later)",
     "dependencies": {}
 }


### PR DESCRIPTION
As per the [LICENSE](https://github.com/Juris-M/citeproc-js/blob/master/LICENSE) file, this project is licensed under either CPAL-1.0 or AGPL-3.0-or-later. This PR updates `package.json` to reflect this, and fixes the syntax as described [here](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license)