### PR TITLE
Percent-encode DOIs when prepended with https://doi.org; fixes #249

### DIFF
--- a/citeproc.js
+++ b/citeproc.js
@@ -15657,6 +15657,11 @@ CSL.Node.text = {
                                                 value = value.replace(/https?:\/\//, "");
                                             }
                                         }
+                                        if (this.variables[0] === "DOI") {
+                                            if (!value.match(/^https?:\/\//) && this.strings.prefix && this.strings.prefix.match(/^.*https:\/\/doi\.org\/$/)) {
+                                                value = CSL.Util.encodeDoiForUrl(value);
+                                            }
+                                        }
                                         // true is for non-suppression of periods
                                         if (state.opt.development_extensions.wrap_url_and_doi) {
                                             if (!this.decorations.length || this.decorations[0][0] !== "@" + this.variables[0]) {
@@ -15671,7 +15676,10 @@ CSL.Node.text = {
                                                     // strip a proper DOI prefix
                                                     var prefix;
                                                     if (this.strings.prefix && this.strings.prefix.match(/^.*https:\/\/doi\.org\/$/)) {
-                                                        value = value.replace(/^https?:\/\/doi\.org\//, "");
+                                                        if (value.match(/^https?:\/\/doi\.org\//)) {
+                                                            value = value.replace(/^https?:\/\/doi\.org\//, "");
+                                                            value = decodeURIComponent(value);
+                                                        }
                                                         if (value.match(/^https?:\/\//)) {
                                                             // Do not tamper with another protocol + domain if already set in field value
                                                             prefix = "";
@@ -15681,6 +15689,9 @@ CSL.Node.text = {
                                                         }
                                                         // set any string prefix on the clone
                                                         clonetoken.strings.prefix = this.strings.prefix.slice(0, clonetoken.strings.prefix.length-16);
+                                                    }
+                                                    if (!value.match(/^https?:\/\//)) {
+                                                        value = CSL.Util.encodeDoiForUrl(value);
                                                     }
                                                     // cast a text blob
                                                     // set the prefix as the content of the blob
@@ -17734,6 +17745,10 @@ CSL.Util.Match = function () {
         };
     };
 
+};
+
+CSL.Util.encodeDoiForUrl = function (doi) {
+    return doi.replace(/[\u0000-\u0020"#%<>?[\\\]^`{|}\u007F-\u009F]/g, encodeURIComponent);
 };
 
 /*global CSL: true */
@@ -22276,7 +22291,7 @@ CSL.Output.Formats.prototype.html = {
     "@DOI/true": function (state, str) {
         var doiurl = str;
         if (!str.match(/^https?:\/\//)) {
-            doiurl = "https://doi.org/" + str;
+            doiurl = "https://doi.org/" + CSL.Util.encodeDoiForUrl(str);
         }
         return "<a href=\"" + doiurl + "\">" + str + "</a>";
     }
@@ -22579,7 +22594,7 @@ CSL.Output.Formats.prototype.asciidoc = {
     "@DOI/true": function (state, str) {
         var doiurl = str;
         if (!str.match(/^https?:\/\//)) {
-            doiurl = "https://doi.org/" + str;
+            doiurl = "https://doi.org/" + CSL.Util.encodeDoiForUrl(str);
         }
         return doiurl + "[" + str + "]";
     }

--- a/citeproc_commonjs.js
+++ b/citeproc_commonjs.js
@@ -15657,6 +15657,11 @@ CSL.Node.text = {
                                                 value = value.replace(/https?:\/\//, "");
                                             }
                                         }
+                                        if (this.variables[0] === "DOI") {
+                                            if (!value.match(/^https?:\/\//) && this.strings.prefix && this.strings.prefix.match(/^.*https:\/\/doi\.org\/$/)) {
+                                                value = CSL.Util.encodeDoiForUrl(value);
+                                            }
+                                        }
                                         // true is for non-suppression of periods
                                         if (state.opt.development_extensions.wrap_url_and_doi) {
                                             if (!this.decorations.length || this.decorations[0][0] !== "@" + this.variables[0]) {
@@ -15671,7 +15676,10 @@ CSL.Node.text = {
                                                     // strip a proper DOI prefix
                                                     var prefix;
                                                     if (this.strings.prefix && this.strings.prefix.match(/^.*https:\/\/doi\.org\/$/)) {
-                                                        value = value.replace(/^https?:\/\/doi\.org\//, "");
+                                                        if (value.match(/^https?:\/\/doi\.org\//)) {
+                                                            value = value.replace(/^https?:\/\/doi\.org\//, "");
+                                                            value = decodeURIComponent(value);
+                                                        }
                                                         if (value.match(/^https?:\/\//)) {
                                                             // Do not tamper with another protocol + domain if already set in field value
                                                             prefix = "";
@@ -15681,6 +15689,9 @@ CSL.Node.text = {
                                                         }
                                                         // set any string prefix on the clone
                                                         clonetoken.strings.prefix = this.strings.prefix.slice(0, clonetoken.strings.prefix.length-16);
+                                                    }
+                                                    if (!value.match(/^https?:\/\//)) {
+                                                        value = CSL.Util.encodeDoiForUrl(value);
                                                     }
                                                     // cast a text blob
                                                     // set the prefix as the content of the blob
@@ -17734,6 +17745,10 @@ CSL.Util.Match = function () {
         };
     };
 
+};
+
+CSL.Util.encodeDoiForUrl = function (doi) {
+    return doi.replace(/[\u0000-\u0020"#%<>?[\\\]^`{|}\u007F-\u009F]/g, encodeURIComponent);
 };
 
 /*global CSL: true */
@@ -22276,7 +22291,7 @@ CSL.Output.Formats.prototype.html = {
     "@DOI/true": function (state, str) {
         var doiurl = str;
         if (!str.match(/^https?:\/\//)) {
-            doiurl = "https://doi.org/" + str;
+            doiurl = "https://doi.org/" + CSL.Util.encodeDoiForUrl(str);
         }
         return "<a href=\"" + doiurl + "\">" + str + "</a>";
     }
@@ -22579,7 +22594,7 @@ CSL.Output.Formats.prototype.asciidoc = {
     "@DOI/true": function (state, str) {
         var doiurl = str;
         if (!str.match(/^https?:\/\//)) {
-            doiurl = "https://doi.org/" + str;
+            doiurl = "https://doi.org/" + CSL.Util.encodeDoiForUrl(str);
         }
         return doiurl + "[" + str + "]";
     }

--- a/src/formats.js
+++ b/src/formats.js
@@ -139,7 +139,7 @@ CSL.Output.Formats.prototype.html = {
     "@DOI/true": function (state, str) {
         var doiurl = str;
         if (!str.match(/^https?:\/\//)) {
-            doiurl = "https://doi.org/" + str;
+            doiurl = "https://doi.org/" + CSL.Util.encodeDoiForUrl(str);
         }
         return "<a href=\"" + doiurl + "\">" + str + "</a>";
     }
@@ -442,7 +442,7 @@ CSL.Output.Formats.prototype.asciidoc = {
     "@DOI/true": function (state, str) {
         var doiurl = str;
         if (!str.match(/^https?:\/\//)) {
-            doiurl = "https://doi.org/" + str;
+            doiurl = "https://doi.org/" + CSL.Util.encodeDoiForUrl(str);
         }
         return doiurl + "[" + str + "]";
     }

--- a/src/node_text.js
+++ b/src/node_text.js
@@ -321,6 +321,11 @@ CSL.Node.text = {
                                                 value = value.replace(/https?:\/\//, "");
                                             }
                                         }
+                                        if (this.variables[0] === "DOI") {
+                                            if (!value.match(/^https?:\/\//) && this.strings.prefix && this.strings.prefix.match(/^.*https:\/\/doi\.org\/$/)) {
+                                                value = CSL.Util.encodeDoiForUrl(value);
+                                            }
+                                        }
                                         // true is for non-suppression of periods
                                         if (state.opt.development_extensions.wrap_url_and_doi) {
                                             if (!this.decorations.length || this.decorations[0][0] !== "@" + this.variables[0]) {
@@ -335,7 +340,10 @@ CSL.Node.text = {
                                                     // strip a proper DOI prefix
                                                     var prefix;
                                                     if (this.strings.prefix && this.strings.prefix.match(/^.*https:\/\/doi\.org\/$/)) {
-                                                        value = value.replace(/^https?:\/\/doi\.org\//, "");
+                                                        if (value.match(/^https?:\/\/doi\.org\//)) {
+                                                            value = value.replace(/^https?:\/\/doi\.org\//, "");
+                                                            value = decodeURIComponent(value);
+                                                        }
                                                         if (value.match(/^https?:\/\//)) {
                                                             // Do not tamper with another protocol + domain if already set in field value
                                                             prefix = "";
@@ -345,6 +353,9 @@ CSL.Node.text = {
                                                         }
                                                         // set any string prefix on the clone
                                                         clonetoken.strings.prefix = this.strings.prefix.slice(0, clonetoken.strings.prefix.length-16);
+                                                    }
+                                                    if (!value.match(/^https?:\/\//)) {
+                                                        value = CSL.Util.encodeDoiForUrl(value);
                                                     }
                                                     // cast a text blob
                                                     // set the prefix as the content of the blob

--- a/src/util.js
+++ b/src/util.js
@@ -56,3 +56,7 @@ CSL.Util.Match = function () {
     };
 
 };
+
+CSL.Util.encodeDoiForUrl = function (doi) {
+    return doi.replace(/[\u0000-\u0020"#%<>?[\\\]^`{|}\u007F-\u009F]/g, encodeURIComponent);
+};


### PR DESCRIPTION
Since DOIs always contain a slash, it's unpleasant to maximally percent-encode them using `encodeURIComponent`.  Code to minimally encode a DOI for appending to https://doi.org is

    doi.replace(/[\u0000-\u0020"#%<>?[\\\]^`{|}\u007F-\u009F]/g, encodeURIComponent)

I've tried to make a pull request that does this in the necessary places.