### PR TITLE
Exempt additional variables from title case in multilingual contexts

### DIFF
--- a/citeproc.js
+++ b/citeproc.js
@@ -301,7 +301,7 @@ var CSL = {
         }
     },
 
-    MULTI_FIELDS: ["event", "publisher", "publisher-place", "event-place", "title", "container-title", "collection-title", "event-title", "original-title", "part-title", "reviewed-title", "volume-title", "authority","genre","title-short","medium","country","jurisdiction","archive","archive-place"],
+    MULTI_FIELDS: ["archive", "archive_collection", "archive_location", "archive-place", "authority", "collection-title", "container-title", "country", "division", "edition", "event", "event-place", "event-title", "genre", "jurisdiction", "medium", "original-publisher", "original-publisher-place", "original-title", "part-title", "publisher", "publisher-place", "reviewed-genre", "reviewed-title", "section", "source", "title", "title-short", "volume-title"],
 
     LangPrefsMap: {
         "title":"titles",

--- a/citeproc_commonjs.js
+++ b/citeproc_commonjs.js
@@ -301,7 +301,7 @@ var CSL = {
         }
     },
 
-    MULTI_FIELDS: ["event", "publisher", "publisher-place", "event-place", "title", "container-title", "collection-title", "event-title", "original-title", "part-title", "reviewed-title", "volume-title", "authority","genre","title-short","medium","country","jurisdiction","archive","archive-place"],
+    MULTI_FIELDS: ["archive", "archive_collection", "archive_location", "archive-place", "authority", "collection-title", "container-title", "country", "division", "edition", "event", "event-place", "event-title", "genre", "jurisdiction", "medium", "original-publisher", "original-publisher-place", "original-title", "part-title", "publisher", "publisher-place", "reviewed-genre", "reviewed-title", "section", "source", "title", "title-short", "volume-title"],
 
     LangPrefsMap: {
         "title":"titles",

--- a/src/load.js
+++ b/src/load.js
@@ -277,7 +277,7 @@ var CSL = {
         }
     },
 
-    MULTI_FIELDS: ["event", "publisher", "publisher-place", "event-place", "title", "container-title", "collection-title", "event-title", "original-title", "part-title", "reviewed-title", "volume-title", "authority","genre","title-short","medium","country","jurisdiction","archive","archive-place"],
+    MULTI_FIELDS: ["archive", "archive_collection", "archive_location", "archive-place", "authority", "collection-title", "container-title", "country", "division", "edition", "event", "event-place", "event-title", "genre", "jurisdiction", "medium", "original-publisher", "original-publisher-place", "original-title", "part-title", "publisher", "publisher-place", "reviewed-genre", "reviewed-title", "section", "source", "title", "title-short", "volume-title"],
 
     LangPrefsMap: {
         "title":"titles",


### PR DESCRIPTION
Include additional variables that should not be rendered in title case outside English, following up on #253.

A report in <https://forums.zotero.org/discussion/comment/502917/#Comment_502917> pointed out that `section` was missing, but logically several others are also missing. For example, it makes no sense that `publisher-place` is treated differently from `original-publisher-place`.