### PR TITLE
Fix condition of locators (fix discourse#1825)

### DIFF
--- a/citeproc.js
+++ b/citeproc.js
@@ -111,7 +111,7 @@ var CSL = {
         "amend.": "amendment",
         "annot.": "annotation",
         "app.": "appendix",
-        "art.": "article",
+        "art.": "article-locator",
         "bibliog.": "bibliography",
         "bk.": "book",
         "ch.": "chapter",
@@ -146,7 +146,7 @@ var CSL = {
         "subsec.": "subsection",
         "supp.": "supplement",
         "tbl.": "table",
-        "tit.": "title",
+        "tit.": "title-locator",
         "vol.": "volume"
     },
     STATUTE_SUBDIV_STRINGS_REVERSE: {
@@ -161,6 +161,7 @@ var CSL = {
         "annotation": "annot.",
         "appendix": "app.",
         "article": "art.",
+        "article-locator": "art.",
         "bibliography": "bibliog.",
         "book": "bk.",
         "chapter": "ch.",
@@ -195,6 +196,7 @@ var CSL = {
         "supplement": "supp.",
         "table": "tbl.",
         "title": "tit.",
+        "title-locator": "tit.",
         "volume": "vol."
     },
 
@@ -208,7 +210,7 @@ var CSL = {
         "amend": "amendment",
         "annot": "annotation",
         "app": "appendix",
-        "art": "article",
+        "art": "article-locator",
         "bibliog": "bibliography",
         "bk": "book",
         "ch": "chapter",
@@ -243,7 +245,7 @@ var CSL = {
         "subsec": "subsection",
         "supp": "supplement",
         "tbl": "table",
-        "tit": "title",
+        "tit": "title-locator",
         "vol": "volume"
     },
     MODULE_MACROS: {
@@ -15915,10 +15917,20 @@ CSL.Attributes["@locator"] = function (state, arg) {
     trylabels = trylabels.split(/\s+/);
     // Strip off any boolean prefix.
     var maketest = function (trylabel) {
+        if (trylabel === "article") {
+            trylabel = "article-locator";
+        } else if (trylabel === "title") {
+            trylabel = "title-locator";
+        }
         return function(Item, item) {
             var label;
             state.processNumber(false, item, "locator");
             label = state.tmp.shadow_numbers.locator.label;
+            // If item.label is not in CSL.STATUTE_SUBDIV_STRINGS_REVERSE,
+            // the label is undefined here.
+            if (!label) {
+                label = item && item.label ? item.label : "page";
+            }
             if (label && trylabel === label) {
                 return true;
             } else {

--- a/citeproc_commonjs.js
+++ b/citeproc_commonjs.js
@@ -111,7 +111,7 @@ var CSL = {
         "amend.": "amendment",
         "annot.": "annotation",
         "app.": "appendix",
-        "art.": "article",
+        "art.": "article-locator",
         "bibliog.": "bibliography",
         "bk.": "book",
         "ch.": "chapter",
@@ -146,7 +146,7 @@ var CSL = {
         "subsec.": "subsection",
         "supp.": "supplement",
         "tbl.": "table",
-        "tit.": "title",
+        "tit.": "title-locator",
         "vol.": "volume"
     },
     STATUTE_SUBDIV_STRINGS_REVERSE: {
@@ -161,6 +161,7 @@ var CSL = {
         "annotation": "annot.",
         "appendix": "app.",
         "article": "art.",
+        "article-locator": "art.",
         "bibliography": "bibliog.",
         "book": "bk.",
         "chapter": "ch.",
@@ -195,6 +196,7 @@ var CSL = {
         "supplement": "supp.",
         "table": "tbl.",
         "title": "tit.",
+        "title-locator": "tit.",
         "volume": "vol."
     },
 
@@ -208,7 +210,7 @@ var CSL = {
         "amend": "amendment",
         "annot": "annotation",
         "app": "appendix",
-        "art": "article",
+        "art": "article-locator",
         "bibliog": "bibliography",
         "bk": "book",
         "ch": "chapter",
@@ -243,7 +245,7 @@ var CSL = {
         "subsec": "subsection",
         "supp": "supplement",
         "tbl": "table",
-        "tit": "title",
+        "tit": "title-locator",
         "vol": "volume"
     },
     MODULE_MACROS: {
@@ -15915,10 +15917,20 @@ CSL.Attributes["@locator"] = function (state, arg) {
     trylabels = trylabels.split(/\s+/);
     // Strip off any boolean prefix.
     var maketest = function (trylabel) {
+        if (trylabel === "article") {
+            trylabel = "article-locator";
+        } else if (trylabel === "title") {
+            trylabel = "title-locator";
+        }
         return function(Item, item) {
             var label;
             state.processNumber(false, item, "locator");
             label = state.tmp.shadow_numbers.locator.label;
+            // If item.label is not in CSL.STATUTE_SUBDIV_STRINGS_REVERSE,
+            // the label is undefined here.
+            if (!label) {
+                label = item && item.label ? item.label : "page";
+            }
             if (label && trylabel === label) {
                 return true;
             } else {

--- a/fixtures/local/condition_Locators.txt
+++ b/fixtures/local/condition_Locators.txt
@@ -1,0 +1,380 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== DESCRIPTION =====>>
+<https://discourse.citationstyles.org/t/unexpected-behavior-with-article-locator/1825>
+<<===== DESCRIPTION =====<<
+
+
+>>===== RESULT =====>>
+act locator: act 42
+appendix locator: app. 42
+article-locator locator: art. 42
+book locator: bk. 42
+canon locator: c. 42
+chapter locator: chap. 42
+column locator: col. 42
+elocation locator: loc. 42
+equation locator: eq. 42
+figure locator: fig. 42
+folio locator: fol. 42
+line locator: l. 42
+note locator: n. 42
+opus locator: op. 42
+paragraph locator: para. 42
+rule locator: r. 42
+scene locator: sc. 42
+sub-verbo locator: s.v. 42
+table locator: tbl. 42
+timestamp locator: 42
+title-locator locator: tit. 42
+verse locator: v. 42
+issue locator: no. 42
+page locator: p. 42
+part locator: pt. 42
+section locator: sec. 42
+supplement locator: supp. 42
+version locator: v. 42
+volume locator: vol. 42
+<<===== RESULT =====<<
+
+
+>>===== CITATION-ITEMS =====>>
+[
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "act"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "appendix"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "article-locator"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "book"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "canon"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "chapter"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "column"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "elocation"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "equation"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "figure"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "folio"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "line"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "note"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "opus"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "paragraph"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "rule"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "scene"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "sub-verbo"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "table"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "timestamp"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "title-locator"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "verse"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "issue"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "page"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "part"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "section"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "supplement"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "version"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "volume"
+        }
+    ]
+]
+<<===== CITATION-ITEMS =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2026-01-24T16:50:04+00:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <group delimiter=" ">
+        <choose>
+          <if locator="act">
+            <text value="act"/>
+          </if>
+          <else-if locator="appendix">
+            <text value="appendix"/>
+          </else-if>
+          <else-if locator="article">
+            <text value="article-locator"/>
+          </else-if>
+          <else-if locator="book">
+            <text value="book"/>
+          </else-if>
+          <else-if locator="canon">
+            <text value="canon"/>
+          </else-if>
+          <else-if locator="chapter">
+            <text value="chapter"/>
+          </else-if>
+          <else-if locator="column">
+            <text value="column"/>
+          </else-if>
+          <else-if locator="elocation">
+            <text value="elocation"/>
+          </else-if>
+          <else-if locator="equation">
+            <text value="equation"/>
+          </else-if>
+          <else-if locator="figure">
+            <text value="figure"/>
+          </else-if>
+          <else-if locator="folio">
+            <text value="folio"/>
+          </else-if>
+          <else-if locator="line">
+            <text value="line"/>
+          </else-if>
+          <else-if locator="note">
+            <text value="note"/>
+          </else-if>
+          <else-if locator="opus">
+            <text value="opus"/>
+          </else-if>
+          <else-if locator="paragraph">
+            <text value="paragraph"/>
+          </else-if>
+          <else-if locator="rule">
+            <text value="rule"/>
+          </else-if>
+          <else-if locator="scene">
+            <text value="scene"/>
+          </else-if>
+          <else-if locator="sub-verbo">
+            <text value="sub-verbo"/>
+          </else-if>
+          <else-if locator="table">
+            <text value="table"/>
+          </else-if>
+          <else-if locator="timestamp">
+            <text value="timestamp"/>
+          </else-if>
+          <else-if locator="title">
+            <text value="title-locator"/>
+          </else-if>
+          <else-if locator="verse">
+            <text value="verse"/>
+          </else-if>
+          <else-if locator="issue">
+            <text value="issue"/>
+          </else-if>
+          <else-if locator="page">
+            <text value="page"/>
+          </else-if>
+          <else-if locator="part">
+            <text value="part"/>
+          </else-if>
+          <else-if locator="section">
+            <text value="section"/>
+          </else-if>
+          <else-if locator="supplement">
+            <text value="supplement"/>
+          </else-if>
+          <else-if locator="version">
+            <text value="version"/>
+          </else-if>
+          <else-if locator="volume">
+            <text value="volume"/>
+          </else-if>
+          <else>
+            <text value="none"/>
+          </else>
+        </choose>
+        <text value="locator:"/>
+        <label variable="locator" form="short"/>
+        <text variable="locator"/>
+      </group>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "id": "ITEM-1",
+        "type": "legislation"
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<

--- a/fixtures/local/condition_LocatorsCslM.txt
+++ b/fixtures/local/condition_LocatorsCslM.txt
@@ -1,0 +1,345 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== DESCRIPTION =====>>
+<https://discourse.citationstyles.org/t/unexpected-behavior-with-article-locator/1825>
+
+These test are the locators in CSL-M but not in CSL v1.0.2.
+<<===== DESCRIPTION =====<<
+
+
+>>===== RESULT =====>>
+addendum locator: add. 42
+amendment locator: amend. 42
+annotation locator: annot. 42
+article locator: art. 42 also matches article-locator
+bibliography locator: bibliog. 42
+clause locator: cl. 42
+comment locator: cmt. 42
+decision locator: dec. 42
+department locator: dept. 42
+example locator: ex. 42
+field locator: fld. 42
+hypothetical locator: hypo. 42
+illustration locator: illus. 42
+introduction locator: intro. 42
+preamble locator: pmbl. 42
+principle locator: princ. 42
+publication locator: pub. 42
+randnummer locator: rn. 42
+schedule locator: sched. 42
+series, locator: ser. 42
+subchapter locator: subch. 42
+subdivision locator: subdiv. 42
+subparagraph locator: subpara. 42
+subsection locator: subsec. 42
+title locator: tit. 42 also matches title-locator
+<<===== RESULT =====<<
+
+
+>>===== CITATION-ITEMS =====>>
+[
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "addendum"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "amendment"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "annotation"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "article"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "bibliography"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "clause"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "comment"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "decision"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "department"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "example"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "field"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "hypothetical"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "illustration"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "introduction"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "preamble"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "principle"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "publication"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "randnummer"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "schedule"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "series,"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "subchapter"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "subdivision"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "subparagraph"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "subsection"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-1",
+            "locator": "42",
+            "label": "title"
+        }
+    ]
+]
+<<===== CITATION-ITEMS =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.1">
+  <info>
+    <id />
+    <title />
+    <updated>2026-01-24T16:48:31+00:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <group delimiter=" ">
+        <choose>
+          <if locator="addendum">
+            <text value="addendum"/>
+          </if>
+          <else-if locator="amendment">
+            <text value="amendment"/>
+          </else-if>
+          <else-if locator="annotation">
+            <text value="annotation"/>
+          </else-if>
+          <else-if locator="article">
+            <text value="article"/>
+          </else-if>
+          <else-if locator="bibliography">
+            <text value="bibliography"/>
+          </else-if>
+          <else-if locator="clause">
+            <text value="clause"/>
+          </else-if>
+          <else-if locator="comment">
+            <text value="comment"/>
+          </else-if>
+          <else-if locator="decision">
+            <text value="decision"/>
+          </else-if>
+          <else-if locator="department">
+            <text value="department"/>
+          </else-if>
+          <else-if locator="example">
+            <text value="example"/>
+          </else-if>
+          <else-if locator="field">
+            <text value="field"/>
+          </else-if>
+          <else-if locator="hypothetical">
+            <text value="hypothetical"/>
+          </else-if>
+          <else-if locator="illustration">
+            <text value="illustration"/>
+          </else-if>
+          <else-if locator="introduction">
+            <text value="introduction"/>
+          </else-if>
+          <else-if locator="preamble">
+            <text value="preamble"/>
+          </else-if>
+          <else-if locator="principle">
+            <text value="principle"/>
+          </else-if>
+          <else-if locator="publication">
+            <text value="publication"/>
+          </else-if>
+          <else-if locator="randnummer">
+            <text value="randnummer"/>
+          </else-if>
+          <else-if locator="schedule">
+            <text value="schedule"/>
+          </else-if>
+          <else-if locator="series,">
+            <text value="series,"/>
+          </else-if>
+          <else-if locator="subchapter">
+            <text value="subchapter"/>
+          </else-if>
+          <else-if locator="subdivision">
+            <text value="subdivision"/>
+          </else-if>
+          <else-if locator="subparagraph">
+            <text value="subparagraph"/>
+          </else-if>
+          <else-if locator="subsection">
+            <text value="subsection"/>
+          </else-if>
+          <else-if locator="title">
+            <text value="title"/>
+          </else-if>
+          <else>
+            <text value="none"/>
+          </else>
+        </choose>
+        <text value="locator:"/>
+        <label variable="locator" form="short"/>
+        <text variable="locator"/>
+        <choose>
+          <if locator="article-locator">
+            <text value="also matches article-locator"/>
+          </if>
+          <else-if locator="title-locator">
+            <text value="also matches title-locator"/>
+          </else-if>
+      </group>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "id": "ITEM-1",
+        "type": "legislation"
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -92,10 +92,20 @@ CSL.Attributes["@locator"] = function (state, arg) {
     trylabels = trylabels.split(/\s+/);
     // Strip off any boolean prefix.
     var maketest = function (trylabel) {
+        if (trylabel === "article") {
+            trylabel = "article-locator";
+        } else if (trylabel === "title") {
+            trylabel = "title-locator";
+        }
         return function(Item, item) {
             var label;
             state.processNumber(false, item, "locator");
             label = state.tmp.shadow_numbers.locator.label;
+            // If item.label is not in CSL.STATUTE_SUBDIV_STRINGS_REVERSE,
+            // the label is undefined here.
+            if (!label) {
+                label = item && item.label ? item.label : "page";
+            }
             if (label && trylabel === label) {
                 return true;
             } else {

--- a/src/load.js
+++ b/src/load.js
@@ -87,7 +87,7 @@ var CSL = {
         "amend.": "amendment",
         "annot.": "annotation",
         "app.": "appendix",
-        "art.": "article",
+        "art.": "article-locator",
         "bibliog.": "bibliography",
         "bk.": "book",
         "ch.": "chapter",
@@ -122,7 +122,7 @@ var CSL = {
         "subsec.": "subsection",
         "supp.": "supplement",
         "tbl.": "table",
-        "tit.": "title",
+        "tit.": "title-locator",
         "vol.": "volume"
     },
     STATUTE_SUBDIV_STRINGS_REVERSE: {
@@ -137,6 +137,7 @@ var CSL = {
         "annotation": "annot.",
         "appendix": "app.",
         "article": "art.",
+        "article-locator": "art.",
         "bibliography": "bibliog.",
         "book": "bk.",
         "chapter": "ch.",
@@ -171,6 +172,7 @@ var CSL = {
         "supplement": "supp.",
         "table": "tbl.",
         "title": "tit.",
+        "title-locator": "tit.",
         "volume": "vol."
     },
 
@@ -184,7 +186,7 @@ var CSL = {
         "amend": "amendment",
         "annot": "annotation",
         "app": "appendix",
-        "art": "article",
+        "art": "article-locator",
         "bibliog": "bibliography",
         "bk": "book",
         "ch": "chapter",
@@ -219,7 +221,7 @@ var CSL = {
         "subsec": "subsection",
         "supp": "supplement",
         "tbl": "table",
-        "tit": "title",
+        "tit": "title-locator",
         "vol": "volume"
     },
     MODULE_MACROS: {


### PR DESCRIPTION
This PR fixes the bug in `locator="article-locator"` condition described in <https://discourse.citationstyles.org/t/unexpected-behavior-with-article-locator/1825>. Now the `"label": "article-locator"` works as expected.

For compatibility with Juris-M, `"label": "article"` matches both conditions of `locator="article"` and `locator="article-locator"`.