### PR TITLE
Fixup malformed XML in tests

### DIFF
--- a/fixtures/local/abbrevs_TitleAbbrevFallback.txt
+++ b/fixtures/local/abbrevs_TitleAbbrevFallback.txt
@@ -37,7 +37,7 @@ M. and M.
 
 
 >>===== CSL =====>>
-<?xml version="1.1mlz1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.1mlz1" class="note" default-locale="en">
   <info>
     <title>Test fixture</title>

--- a/fixtures/local/abbrevs_TitleMainTitleSub.txt
+++ b/fixtures/local/abbrevs_TitleMainTitleSub.txt
@@ -78,10 +78,11 @@ sub: Fourth subtitle
   <citation>
     <layout>
       <group delimiter="&#x0A;" suffix="&#x0A;">
-      <text variable="title" prefix="full: "/>
-      <text variable="title" form="short" prefix="short: "/>
-      <text variable="title-main" prefix="main: "/>
-      <text variable="title-sub" prefix="sub: "/>
+        <text variable="title" prefix="full: "/>
+        <text variable="title" form="short" prefix="short: "/>
+        <text variable="title-main" prefix="main: "/>
+        <text variable="title-sub" prefix="sub: "/>
+      </group>
     </layout>
   </citation>
 </style>

--- a/fixtures/local/bugreports_dailDebates.txt
+++ b/fixtures/local/bugreports_dailDebates.txt
@@ -30,7 +30,7 @@ citation
 <<===== CITATIONS =====<<
 
 >>===== CSL =====>>
-<?xml version="1.1mlz1" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" page-range-format="chicago" version="1.1mlz1" year-range-format="expanded">
   <info>
     <title>Test fixture</title>

--- a/fixtures/local/condition_Locale.txt
+++ b/fixtures/local/condition_Locale.txt
@@ -88,6 +88,7 @@ Author Bob; Container Bob (編); Secondary Bob (訳)
             <text macro="container-contributors"/>
             <text macro="secondary-contributors"/>
           </else>
+        </choose>
       </group>
     </layout>
   </citation>

--- a/fixtures/local/condition_LocatorsCslM.txt
+++ b/fixtures/local/condition_LocatorsCslM.txt
@@ -323,6 +323,7 @@ title locator: tit. 42 also matches title-locator
           <else-if locator="title-locator">
             <text value="also matches title-locator"/>
           </else-if>
+        </choose>
       </group>
     </layout>
   </citation>

--- a/fixtures/local/discretionary_CitationNumberAuthorOnlyThenSuppressAuthor.txt
+++ b/fixtures/local/discretionary_CitationNumberAuthorOnlyThenSuppressAuthor.txt
@@ -96,7 +96,7 @@ citation
   <bibliography>
     <layout>
       <group delimiter=" ">
-        <text variable="citation-number" suffix=".">
+        <text variable="citation-number" suffix="."/>
         <text variable="title" />
       </group>
     </layout>

--- a/fixtures/local/discretionary_CitationNumberAuthorOnlyThenSuppressAuthorWithIntext.txt
+++ b/fixtures/local/discretionary_CitationNumberAuthorOnlyThenSuppressAuthorWithIntext.txt
@@ -96,7 +96,7 @@ citation
   <bibliography>
     <layout>
       <group delimiter=" ">
-        <text variable="citation-number" suffix=".">
+        <text variable="citation-number" suffix="."/>
         <text variable="title" />
       </group>
     </layout>

--- a/fixtures/local/institutions_AffiliationSpoofingItalicInstitutionHarvard.txt
+++ b/fixtures/local/institutions_AffiliationSpoofingItalicInstitutionHarvard.txt
@@ -25,7 +25,7 @@ selectively if there are requests to do so.
 
 
 >>===== CSL =====>>
-<?xml version="1.1mlz1" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.1mlz1">
    <info>
     <title>Test fixture</title>

--- a/fixtures/local/institutions_AffiliationSpoofingItalicInstitutionHarvardBib.txt
+++ b/fixtures/local/institutions_AffiliationSpoofingItalicInstitutionHarvardBib.txt
@@ -19,7 +19,7 @@ bibliography
 
 
 >>===== CSL =====>>
-<?xml version="1.1mlz1" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.1mlz1">
    <info>
     <title>Test fixture</title>

--- a/fixtures/local/institutions_ItalicInstitutionHarvard.txt
+++ b/fixtures/local/institutions_ItalicInstitutionHarvard.txt
@@ -19,7 +19,7 @@ selectively if there are requests to do so.
 
 
 >>===== CSL =====>>
-<?xml version="1.1mlz1" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.1mlz1">
    <info>
     <title>Test fixture</title>

--- a/fixtures/local/institutions_ItalicInstitutionHarvardBib.txt
+++ b/fixtures/local/institutions_ItalicInstitutionHarvardBib.txt
@@ -13,7 +13,7 @@ bibliography
 
 
 >>===== CSL =====>>
-<?xml version="1.1mlz1" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.1mlz1">
    <info>
     <title>Test fixture</title>

--- a/fixtures/local/language_ConditionSimple.txt
+++ b/fixtures/local/language_ConditionSimple.txt
@@ -59,7 +59,6 @@ P. Writer, J. Scriber, An English Title, K. Editor, ed., English Work.
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <group delimiter=", ">
-        <choose>
         <names variable="author">
           <name initialize-with=". "/>
           <label form="short" prefix=", "/>

--- a/fixtures/local/number_EmbeddedOnlyDefaultsToShort.txt
+++ b/fixtures/local/number_EmbeddedOnlyDefaultsToShort.txt
@@ -58,7 +58,6 @@ citation
           <number variable="volume"/>
         </group>
         <number variable="page"/>
-	</group>
       </group>
     </layout>
   </citation>

--- a/fixtures/local/parallel_NewZealand.txt
+++ b/fixtures/local/parallel_NewZealand.txt
@@ -12,7 +12,7 @@ Failing parallel collapse in New Zealand Law style
 
 
 >>===== CSL =====>>
-<?xml version="1.1mlz1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.1mlz1" class="note" default-locale="en">
   <info>
     <title>Test fixture</title>

--- a/fixtures/local/range_PageMinimal.txt
+++ b/fixtures/local/range_PageMinimal.txt
@@ -47,7 +47,7 @@ should pass test style_test001
       <number variable="page"/>
     </layout>
   </bibliography>
-
+</style>
 <<===== CSL =====<<
 
 >>===== INPUT =====>>

--- a/fixtures/local/style-hhkk_Style.txt
+++ b/fixtures/local/style-hhkk_Style.txt
@@ -591,7 +591,7 @@ citation
 <<== ABBREVIATIONS ==<<
 
 >>===== CSL =====>>
-<?xml version="1.1mlz1" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.1mlz1" year-range-format="expanded" default-locale="ja-x-translit-ja-hrkt">
   <info>
     <title>Test fixture</title>


### PR DESCRIPTION
This PR fixes all the malformed XML in tests.

These bugs do not affect the citeproc-js XML parser and therefore do not cause running errors.