### PR TITLE
Fix name attributes with literal names (fix #271)

### DIFF
--- a/citeproc.js
+++ b/citeproc.js
@@ -1580,7 +1580,6 @@ CSL.XmlJSON = function (dataObj) {
         name:"institution",
         attrs:{
             "institution-parts":"long",
-            "delimiter":", "
         },
         children:[
             {

--- a/citeproc.js
+++ b/citeproc.js
@@ -1981,8 +1981,6 @@ CSL.XmlJSON.prototype.addInstitutionNodes = function(myjson) {
                 for (var key in myjson.children[i].attrs) {
                     attributes[key] = myjson.children[i].attrs[key];
                 }
-                attributes.delimiter = myjson.children[i].attrs.delimiter;
-                attributes.and = myjson.children[i].attrs.and;
                 insertPos = i;
                 for (var k=0,klen=myjson.children[i].children.length;k<klen;k+=1) {
                     if (myjson.children[i].children[k].attrs.name !== 'family') {
@@ -2000,16 +1998,16 @@ CSL.XmlJSON.prototype.addInstitutionNodes = function(myjson) {
         }
         if (insertPos > -1) {
             var institution = this.nodeCopy(this.institution);
+            for (var i = 0, ilen = CSL.NAME_ATTRIBUTES.length; i < ilen; i += 1) {
+                var attrname = CSL.NAME_ATTRIBUTES[i];
+                if ("undefined" !== typeof attributes[attrname]) {
+                    institution.attrs[attrname] = attributes[attrname];
+                }
+            }
             for (var i=0,ilen = CSL.INSTITUTION_KEYS.length;i<ilen;i+=1) {
                 var attrname = CSL.INSTITUTION_KEYS[i];
                 if ("undefined" !== typeof attributes[attrname]) {
                     institution.children[0].attrs[attrname] = attributes[attrname];
-                }
-                if (attributes.delimiter) {
-                    institution.attrs.delimiter = attributes.delimiter;
-                }
-                if (attributes.and) {
-                    institution.attrs.and = attributes.and;
                 }
             }
             myjson.children = myjson.children.slice(0,insertPos+1).concat([institution]).concat(myjson.children.slice(insertPos+1));

--- a/citeproc_commonjs.js
+++ b/citeproc_commonjs.js
@@ -1580,7 +1580,6 @@ CSL.XmlJSON = function (dataObj) {
         name:"institution",
         attrs:{
             "institution-parts":"long",
-            "delimiter":", "
         },
         children:[
             {

--- a/citeproc_commonjs.js
+++ b/citeproc_commonjs.js
@@ -1981,8 +1981,6 @@ CSL.XmlJSON.prototype.addInstitutionNodes = function(myjson) {
                 for (var key in myjson.children[i].attrs) {
                     attributes[key] = myjson.children[i].attrs[key];
                 }
-                attributes.delimiter = myjson.children[i].attrs.delimiter;
-                attributes.and = myjson.children[i].attrs.and;
                 insertPos = i;
                 for (var k=0,klen=myjson.children[i].children.length;k<klen;k+=1) {
                     if (myjson.children[i].children[k].attrs.name !== 'family') {
@@ -2000,16 +1998,16 @@ CSL.XmlJSON.prototype.addInstitutionNodes = function(myjson) {
         }
         if (insertPos > -1) {
             var institution = this.nodeCopy(this.institution);
+            for (var i = 0, ilen = CSL.NAME_ATTRIBUTES.length; i < ilen; i += 1) {
+                var attrname = CSL.NAME_ATTRIBUTES[i];
+                if ("undefined" !== typeof attributes[attrname]) {
+                    institution.attrs[attrname] = attributes[attrname];
+                }
+            }
             for (var i=0,ilen = CSL.INSTITUTION_KEYS.length;i<ilen;i+=1) {
                 var attrname = CSL.INSTITUTION_KEYS[i];
                 if ("undefined" !== typeof attributes[attrname]) {
                     institution.children[0].attrs[attrname] = attributes[attrname];
-                }
-                if (attributes.delimiter) {
-                    institution.attrs.delimiter = attributes.delimiter;
-                }
-                if (attributes.and) {
-                    institution.attrs.and = attributes.and;
                 }
             }
             myjson.children = myjson.children.slice(0,insertPos+1).concat([institution]).concat(myjson.children.slice(insertPos+1));

--- a/fixtures/local/nameattr_DelimiterPrecedesLastWithLiteralName.txt
+++ b/fixtures/local/nameattr_DelimiterPrecedesLastWithLiteralName.txt
@@ -1,0 +1,96 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== DESCRIPTION =====>>
+https://github.com/Juris-M/citeproc-js/issues/271
+<<===== DESCRIPTION =====<<
+
+
+>>===== RESULT =====>>
+Norge, Danmark and Island
+John Doe, Jane Roe and Richard Smith
+<<===== RESULT =====<<
+
+
+>>===== CITATION-ITEMS =====>>
+[
+    [
+        {
+            "id": "ITEM-1"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-2"
+        }
+    ]
+]
+<<===== CITATION-ITEMS =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2026-02-10T11:37:01+00:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <names variable="author">
+        <name and="text" delimiter-precedes-last="never"/>
+        <!-- <institution and="text" delimiter-precedes-last="never"/> -->
+      </names>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "id": "ITEM-1",
+        "type": "treaty",
+        "author": [
+            {
+                "literal": "Norge"
+            },
+            {
+                "literal": "Danmark"
+            },
+            {
+                "literal": "Island"
+            }
+        ]
+    },
+    {
+        "id": "ITEM-2",
+        "type": "book",
+        "author": [
+            {
+                "family": "Doe",
+                "given": "John"
+            },
+            {
+                "family": "Roe",
+                "given": "Jane"
+            },
+            {
+                "family": "Smith",
+                "given": "Richard"
+            }
+        ]
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<

--- a/fixtures/local/nameattr_InheritedDelimiterWIthLiteralNames.txt
+++ b/fixtures/local/nameattr_InheritedDelimiterWIthLiteralNames.txt
@@ -1,0 +1,94 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== DESCRIPTION =====>>
+The name delimiter inherited from `<style>` element should also work with literal names.
+
+<http://github.com/Juris-M/citeproc-js/issues/273>
+<<===== DESCRIPTION =====<<
+
+
+>>===== RESULT =====>>
+Literal 1; Literal 2; Literal 3 | Literal 1. Literal 2. Literal 3
+Doe; Roe; Smith | Doe. Roe. Smith
+<<===== RESULT =====<<
+
+
+>>===== CITATION-ITEMS =====>>
+[
+    [
+        {
+            "id": "ITEM-1"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-2"
+        }
+    ]
+]
+<<===== CITATION-ITEMS =====<<
+
+
+>>===== CSL =====>>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" name-delimiter="; ">
+  <info>
+    <title/>
+    <id/>
+    <updated>2026-02-10T12:30:13+00:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <names variable="author">
+        <name/>
+      </names>
+      <names variable="author" prefix=" | ">
+        <name delimiter=". "/>
+      </names>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "id": "ITEM-1",
+        "type": "book",
+        "author": [
+            {
+                "literal": "Literal 1"
+            },
+            {
+                "literal": "Literal 2"
+            },
+            {
+                "literal": "Literal 3"
+            }
+        ]
+    },
+    {
+        "id": "ITEM-2",
+        "type": "book",
+        "author": [
+            {
+                "family": "Doe"
+            },
+            {
+                "family": "Roe"
+            },
+            {
+                "family": "Smith"
+            }
+        ]
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<

--- a/src/xmljson.js
+++ b/src/xmljson.js
@@ -27,7 +27,6 @@ CSL.XmlJSON = function (dataObj) {
         name:"institution",
         attrs:{
             "institution-parts":"long",
-            "delimiter":", "
         },
         children:[
             {

--- a/src/xmljson.js
+++ b/src/xmljson.js
@@ -428,8 +428,6 @@ CSL.XmlJSON.prototype.addInstitutionNodes = function(myjson) {
                 for (var key in myjson.children[i].attrs) {
                     attributes[key] = myjson.children[i].attrs[key];
                 }
-                attributes.delimiter = myjson.children[i].attrs.delimiter;
-                attributes.and = myjson.children[i].attrs.and;
                 insertPos = i;
                 for (var k=0,klen=myjson.children[i].children.length;k<klen;k+=1) {
                     if (myjson.children[i].children[k].attrs.name !== 'family') {
@@ -447,16 +445,16 @@ CSL.XmlJSON.prototype.addInstitutionNodes = function(myjson) {
         }
         if (insertPos > -1) {
             var institution = this.nodeCopy(this.institution);
+            for (var i = 0, ilen = CSL.NAME_ATTRIBUTES.length; i < ilen; i += 1) {
+                var attrname = CSL.NAME_ATTRIBUTES[i];
+                if ("undefined" !== typeof attributes[attrname]) {
+                    institution.attrs[attrname] = attributes[attrname];
+                }
+            }
             for (var i=0,ilen = CSL.INSTITUTION_KEYS.length;i<ilen;i+=1) {
                 var attrname = CSL.INSTITUTION_KEYS[i];
                 if ("undefined" !== typeof attributes[attrname]) {
                     institution.children[0].attrs[attrname] = attributes[attrname];
-                }
-                if (attributes.delimiter) {
-                    institution.attrs.delimiter = attributes.delimiter;
-                }
-                if (attributes.and) {
-                    institution.attrs.and = attributes.and;
                 }
             }
             myjson.children = myjson.children.slice(0,insertPos+1).concat([institution]).concat(myjson.children.slice(insertPos+1));


### PR DESCRIPTION
In this PR, the attributes of `<name>` element are copied to the automatically added `<institution>` element. This should fix #271.