### PR TITLE
Fix chicago-15 page-range abbreviation for 5+ digit numbers

### DIFF
--- a/citeproc.js
+++ b/citeproc.js
@@ -21099,7 +21099,14 @@ CSL.Util.PageRangeMangler.getFunction = function (state, rangeType) {
                 if (begin > 100 && begin % 100 && parseInt((begin / 100), 10) === parseInt((end / 100), 10)) {
                     m[3] = "" + (end % 100);
                 } else if (begin >= 10000) {
-                    m[3] = "" + (end % 1000);
+                    e = "" + end;
+                    for (var i = 3; i < e.length; i++) {
+                        var divisor = Math.pow(10, i);
+                        if (Math.floor(begin / divisor) === Math.floor(end / divisor)) {
+                            m[3] = "" + (end % divisor);
+                            break;
+                        }
+                    }
                 }
             }
             if (m[2].slice(1) === m[0]) {

--- a/citeproc_commonjs.js
+++ b/citeproc_commonjs.js
@@ -21099,7 +21099,14 @@ CSL.Util.PageRangeMangler.getFunction = function (state, rangeType) {
                 if (begin > 100 && begin % 100 && parseInt((begin / 100), 10) === parseInt((end / 100), 10)) {
                     m[3] = "" + (end % 100);
                 } else if (begin >= 10000) {
-                    m[3] = "" + (end % 1000);
+                    e = "" + end;
+                    for (var i = 3; i < e.length; i++) {
+                        var divisor = Math.pow(10, i);
+                        if (Math.floor(begin / divisor) === Math.floor(end / divisor)) {
+                            m[3] = "" + (end % divisor);
+                            break;
+                        }
+                    }
                 }
             }
             if (m[2].slice(1) === m[0]) {

--- a/src/util_page.js
+++ b/src/util_page.js
@@ -121,7 +121,14 @@ CSL.Util.PageRangeMangler.getFunction = function (state, rangeType) {
                 if (begin > 100 && begin % 100 && parseInt((begin / 100), 10) === parseInt((end / 100), 10)) {
                     m[3] = "" + (end % 100);
                 } else if (begin >= 10000) {
-                    m[3] = "" + (end % 1000);
+                    e = "" + end;
+                    for (var i = 3; i < e.length; i++) {
+                        var divisor = Math.pow(10, i);
+                        if (Math.floor(begin / divisor) === Math.floor(end / divisor)) {
+                            m[3] = "" + (end % divisor);
+                            break;
+                        }
+                    }
                 }
             }
             if (m[2].slice(1) === m[0]) {


### PR DESCRIPTION
The chicago15 function hardcoded `end % 1000` for numbers >= 10000 when the hundreds differed, which produced incorrect results when higher digit places also changed (e.g., 11153-12359 became 11153-359 instead of 11153-2359) [1].

Replace the hardcoded logic with an iterative approach (matching what chicago16 already uses) that walks up powers of 10 until it finds where begin and end share the same leading digits.

The >= 10000 condition is intentional: per the CSL spec (Appendix V), chicago-15 has a special rule for 4-digit numbers where three digits change (e.g., 1496-1504, 2787-2816), requiring all digits be kept. chicago-16 does not have this rule.

[1] https://forums.zotero.org/discussion/130805/bug-report-page-number-digit-gets-swallowed