### PR TITLE
Cache sort-mode macro expansions to reduce memory usage and speed up engine initialization

### DIFF
--- a/citeproc.js
+++ b/citeproc.js
@@ -2973,7 +2973,19 @@ CSL.expandMacro = function (macro_key_token, target) {
         CSL.buildMacro.call(this, mytarget, macro_nodes);
         CSL.configureMacro.call(this, mytarget);
     }
-    if (!this.build.extension) {
+    if (this.build.extension) {
+        var func = (function(macro_name) {
+            return function (state, Item, item) {
+                var next = 0;
+                while (next < state.sort_macros[macro_name].length) {
+                    next = CSL.tokenExec.call(state, state.sort_macros[macro_name][next], Item, item);
+                }
+            };
+        }(mkey));
+        var text_node = new CSL.Token("text", CSL.SINGLETON);
+        text_node.execs.push(func);
+        target.push(text_node);
+    } else {
         var func = (function(macro_name) {
             return function (state, Item, item) {
                 var next = 0;
@@ -3011,7 +3023,16 @@ CSL.expandMacro = function (macro_key_token, target) {
 CSL.getMacroTarget = function (mkey) {
     var mytarget = false;
     if (this.build.extension) {
-        mytarget = this[this.build.root + this.build.extension].tokens;
+        // Cache sort-mode macro expansions separately, just like non-sort macros.
+        // This avoids duplicating tokens when the same macro is referenced by
+        // multiple sort keys.
+        if (!this.sort_macros) {
+            this.sort_macros = {};
+        }
+        if (!this.sort_macros[mkey]) {
+            mytarget = [];
+            this.sort_macros[mkey] = mytarget;
+        }
     } else if (!this.macros[mkey]) {
         mytarget = [];
         this.macros[mkey] = mytarget;
@@ -3031,9 +3052,7 @@ CSL.buildMacro = function (mytarget, macro_nodes) {
 };
 
 CSL.configureMacro = function (mytarget) {
-    if (!this.build.extension) {
-        this.configureTokenList(mytarget);
-    }
+    this.configureTokenList(mytarget);
 };
 
 

--- a/citeproc_commonjs.js
+++ b/citeproc_commonjs.js
@@ -2973,7 +2973,19 @@ CSL.expandMacro = function (macro_key_token, target) {
         CSL.buildMacro.call(this, mytarget, macro_nodes);
         CSL.configureMacro.call(this, mytarget);
     }
-    if (!this.build.extension) {
+    if (this.build.extension) {
+        var func = (function(macro_name) {
+            return function (state, Item, item) {
+                var next = 0;
+                while (next < state.sort_macros[macro_name].length) {
+                    next = CSL.tokenExec.call(state, state.sort_macros[macro_name][next], Item, item);
+                }
+            };
+        }(mkey));
+        var text_node = new CSL.Token("text", CSL.SINGLETON);
+        text_node.execs.push(func);
+        target.push(text_node);
+    } else {
         var func = (function(macro_name) {
             return function (state, Item, item) {
                 var next = 0;
@@ -3011,7 +3023,16 @@ CSL.expandMacro = function (macro_key_token, target) {
 CSL.getMacroTarget = function (mkey) {
     var mytarget = false;
     if (this.build.extension) {
-        mytarget = this[this.build.root + this.build.extension].tokens;
+        // Cache sort-mode macro expansions separately, just like non-sort macros.
+        // This avoids duplicating tokens when the same macro is referenced by
+        // multiple sort keys.
+        if (!this.sort_macros) {
+            this.sort_macros = {};
+        }
+        if (!this.sort_macros[mkey]) {
+            mytarget = [];
+            this.sort_macros[mkey] = mytarget;
+        }
     } else if (!this.macros[mkey]) {
         mytarget = [];
         this.macros[mkey] = mytarget;
@@ -3031,9 +3052,7 @@ CSL.buildMacro = function (mytarget, macro_nodes) {
 };
 
 CSL.configureMacro = function (mytarget) {
-    if (!this.build.extension) {
-        this.configureTokenList(mytarget);
-    }
+    this.configureTokenList(mytarget);
 };
 
 

--- a/src/util_nodes.js
+++ b/src/util_nodes.js
@@ -113,7 +113,19 @@ CSL.expandMacro = function (macro_key_token, target) {
         CSL.buildMacro.call(this, mytarget, macro_nodes);
         CSL.configureMacro.call(this, mytarget);
     }
-    if (!this.build.extension) {
+    if (this.build.extension) {
+        var func = (function(macro_name) {
+            return function (state, Item, item) {
+                var next = 0;
+                while (next < state.sort_macros[macro_name].length) {
+                    next = CSL.tokenExec.call(state, state.sort_macros[macro_name][next], Item, item);
+                }
+            };
+        }(mkey));
+        var text_node = new CSL.Token("text", CSL.SINGLETON);
+        text_node.execs.push(func);
+        target.push(text_node);
+    } else {
         var func = (function(macro_name) {
             return function (state, Item, item) {
                 var next = 0;
@@ -151,7 +163,16 @@ CSL.expandMacro = function (macro_key_token, target) {
 CSL.getMacroTarget = function (mkey) {
     var mytarget = false;
     if (this.build.extension) {
-        mytarget = this[this.build.root + this.build.extension].tokens;
+        // Cache sort-mode macro expansions separately, just like non-sort macros.
+        // This avoids duplicating tokens when the same macro is referenced by
+        // multiple sort keys.
+        if (!this.sort_macros) {
+            this.sort_macros = {};
+        }
+        if (!this.sort_macros[mkey]) {
+            mytarget = [];
+            this.sort_macros[mkey] = mytarget;
+        }
     } else if (!this.macros[mkey]) {
         mytarget = [];
         this.macros[mkey] = mytarget;
@@ -171,9 +192,7 @@ CSL.buildMacro = function (mytarget, macro_nodes) {
 };
 
 CSL.configureMacro = function (mytarget) {
-    if (!this.build.extension) {
-        this.configureTokenList(mytarget);
-    }
+    this.configureTokenList(mytarget);
 };
 
 

--- a/tools/mem_test.js
+++ b/tools/mem_test.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+"use strict";
+
+// Memory usage test for CSL.Engine instantiation.
+//
+// Usage: node --expose-gc mem_test.js [path-to-style.csl]
+//
+// If no style path is provided, downloads chicago-shortened-notes-bibliography
+// from the citation-style-language/styles repo (155 macros, 6 macro-based sort
+// keys -- good for memory testing).
+
+var fs = require("fs");
+var path = require("path");
+var ROOT = path.join(__dirname, "..");
+var CSL = require(path.join(ROOT, "citeproc_commonjs.js"));
+
+var STYLE_URL = "https://raw.githubusercontent.com/citation-style-language/styles/master/chicago-shortened-notes-bibliography.csl";
+var CACHED_STYLE_PATH = path.join(require("os").tmpdir(), "citeproc-mem-test-chicago-shortened-notes-bibliography.csl");
+var FALLBACK_STYLE_PATH = path.join(ROOT, "docs", "chicago-fullnote-bibliography.csl");
+
+// Load locale
+var localeXml = fs.readFileSync(path.join(ROOT, "locale", "locales-en-US.xml"), "utf8");
+
+// Load style
+var stylePath = process.argv[2];
+var styleXml;
+if (stylePath) {
+	styleXml = fs.readFileSync(stylePath, "utf8");
+}
+else if (fs.existsSync(CACHED_STYLE_PATH)) {
+	stylePath = CACHED_STYLE_PATH;
+	styleXml = fs.readFileSync(CACHED_STYLE_PATH, "utf8");
+}
+else {
+	// Download chicago-shortened-notes-bibliography and cache in tmp
+	try {
+		console.log("Downloading style...");
+		var execFileSync = require("child_process").execFileSync;
+		styleXml = execFileSync("curl", ["-sfL", STYLE_URL], { encoding: "utf8" });
+		fs.writeFileSync(CACHED_STYLE_PATH, styleXml);
+		stylePath = CACHED_STYLE_PATH;
+	}
+	catch (e) {
+		console.log("Download failed, falling back to " + FALLBACK_STYLE_PATH);
+		stylePath = FALLBACK_STYLE_PATH;
+		styleXml = fs.readFileSync(FALLBACK_STYLE_PATH, "utf8");
+	}
+}
+console.log("Style: " + stylePath);
+
+// Minimal sys object
+var sys = {
+	retrieveLocale: function (lang) {
+		if (lang === "en-US") return localeXml;
+		try {
+			return fs.readFileSync(path.join(ROOT, "locale", "locales-" + lang + ".xml"), "utf8");
+		}
+		catch (e) {
+			return null;
+		}
+	},
+	retrieveItem: function (id) {
+		return {};
+	}
+};
+
+function gc() {
+	if (global.gc) {
+		global.gc();
+		global.gc();
+		global.gc();
+	}
+}
+
+function heapMB() {
+	gc();
+	return Math.round(process.memoryUsage().heapUsed / 1024 / 1024 * 10) / 10;
+}
+
+// Warm up -- load code paths
+var warmup = new CSL.Engine(sys, styleXml, "en-US");
+warmup = null;
+gc();
+
+var RUNS = 5;
+
+console.log("Creating " + RUNS + " CSL.Engine instances...\n");
+
+var baseline = heapMB();
+console.log("Baseline heap: " + baseline + " MB");
+
+var engines = [];
+for (var i = 0; i < RUNS; i++) {
+	var before = heapMB();
+	engines.push(new CSL.Engine(sys, styleXml, "en-US"));
+	var after = heapMB();
+	console.log("Engine " + (i + 1) + ": " + before + " -> " + after + " MB (delta=" + (after - before).toFixed(1) + " MB)");
+}
+
+console.log("\nTotal heap after " + RUNS + " engines: " + heapMB() + " MB");
+console.log("Total delta from baseline: " + (heapMB() - baseline).toFixed(1) + " MB");
+console.log("Average per engine: " + ((heapMB() - baseline) / RUNS).toFixed(1) + " MB");


### PR DESCRIPTION
Previously, macros referenced by sort keys were expanded inline into the sort token array every time they were encountered. Non-sort macros were already cached in state.macros[name] and referenced via closures, but sort-mode macros were duplicated across sort keys.

With a complex style like chicago-shortened-notes-bibliography (155 macros, 6 macro-based sort keys), this produced 179,605 tokens and 355,652 closures in bibliography_sort alone -- 99.9% of all tokens.

This commit caches sort-mode macro expansions in state.sort_macros[name] using the same closure-reference approach as non-sort macros.

In addition to the memory savings, avoiding the redundant macro expansion makes engine initialization dramatically faster with complex styles.

Results with chicago-shortened-notes-bibliography:
- Engine initialization: 464 ms -> 57 ms (8x faster)
- Per-engine heap (Node.js): 123 MB -> 6.7 MB (94.6% reduction)
- Total tokens: 187,893 -> 11,669 (93.8% reduction)
- Total closures: 370,982 -> 21,823 (94.1% reduction)
- All 1,502 citeproc-js tests pass (at f88a47e6)
- Same 1501/1505 pass on master (same 4 pre-existing failures)

Also adds tools/mem_test.js, which can be used to measure per-engine heap usage with `node --expose-gc tools/mem_test.js`.

(Needless to say, this was identified and fixed by AI, but all existing passing tests still pass, and this change has been in Zotero betas since mid-February and in Zotero 9 for the last couple weeks with no reported regressions.)