### PR TITLE
Restore processor state when previewCitationCluster() fails

### DIFF
--- a/citeproc.js
+++ b/citeproc.js
@@ -6942,9 +6942,13 @@ CSL.Engine.prototype.previewCitationCluster = function (citation, citationsPre, 
 	if (citation.citationID) {
 		delete citation.citationID;
 	}
-    var ret = this.processCitationCluster(citation, citationsPre, citationsPost, CSL.PREVIEW);
-
-    this.setOutputFormat(oldMode);
+    // Restore the output format even if the preview fails
+    var ret;
+    try {
+        ret = this.processCitationCluster(citation, citationsPre, citationsPost, CSL.PREVIEW);
+    } finally {
+        this.setOutputFormat(oldMode);
+    }
     return ret[1];
 };
 
@@ -7660,53 +7664,55 @@ CSL.Engine.prototype.processCitationCluster = function (citation, citationsPre, 
             ret = this.process_CitationCluster.call(this, citation.sortedItems, citation);
         } catch (e) {
             CSL.error("Error running CSL processor for preview: "+e);
-        }
-            
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** end run processor *********");
-            CSL.debug("****** start state restore *********");
-        }
-        //SNIP-END
-        // Wind out anything related to new items added for the preview.
-        // This means (1) names, (2) disambig state for affected items,
-        // (3) keys registered in the ambigs pool arrays, and (4) registry
-        // items.
-        //
+        } finally {
+            // Restore state even if an error occurred above
 
-        // restore sliced citations
-        this.registry.citationreg.citationByIndex = oldCitationList;
-        this.registry.citationreg.citationById = {};
-        for (var i = 0, ilen = oldCitationList.length; i < ilen; i += 1) {
-            this.registry.citationreg.citationById[oldCitationList[i].citationID] = oldCitationList[i];
-        }
-
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** start final update *********");
-        }
-        //SNIP-END
-        var oldItemIds = [];
-        for (var i = 0, ilen = oldItemList.length; i < ilen; i += 1) {
-            oldItemIds.push("" + oldItemList[i].id);
-        }
-        this.updateItems(oldItemIds, null, null, true);
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** end final update *********");
-        }
-        //SNIP-END
-        // Roll back disambig states
-        for (var key in oldAmbigs) {
-            if (oldAmbigs.hasOwnProperty(key)) {
-                this.registry.registry[key].disambig = oldAmbigs[key];
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** end run processor *********");
+                CSL.debug("****** start state restore *********");
             }
+            //SNIP-END
+            // Wind out anything related to new items added for the preview.
+            // This means (1) names, (2) disambig state for affected items,
+            // (3) keys registered in the ambigs pool arrays, and (4) registry
+            // items.
+            //
+
+            // restore sliced citations
+            this.registry.citationreg.citationByIndex = oldCitationList;
+            this.registry.citationreg.citationById = {};
+            for (var i = 0, ilen = oldCitationList.length; i < ilen; i += 1) {
+                this.registry.citationreg.citationById[oldCitationList[i].citationID] = oldCitationList[i];
+            }
+
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** start final update *********");
+            }
+            //SNIP-END
+            var oldItemIds = [];
+            for (var i = 0, ilen = oldItemList.length; i < ilen; i += 1) {
+                oldItemIds.push("" + oldItemList[i].id);
+            }
+            this.updateItems(oldItemIds, null, null, true);
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** end final update *********");
+            }
+            //SNIP-END
+            // Roll back disambig states
+            for (var key in oldAmbigs) {
+                if (oldAmbigs.hasOwnProperty(key)) {
+                    this.registry.registry[key].disambig = oldAmbigs[key];
+                }
+            }
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** end state restore *********");
+            }
+            //SNIP-END
         }
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** end state restore *********");
-        }
-        //SNIP-END
     } else {
         // Rerun cites that have moved across citations or had a change
         // in their number of subsequent references, so that disambiguate

--- a/citeproc_commonjs.js
+++ b/citeproc_commonjs.js
@@ -6942,9 +6942,13 @@ CSL.Engine.prototype.previewCitationCluster = function (citation, citationsPre, 
 	if (citation.citationID) {
 		delete citation.citationID;
 	}
-    var ret = this.processCitationCluster(citation, citationsPre, citationsPost, CSL.PREVIEW);
-
-    this.setOutputFormat(oldMode);
+    // Restore the output format even if the preview fails
+    var ret;
+    try {
+        ret = this.processCitationCluster(citation, citationsPre, citationsPost, CSL.PREVIEW);
+    } finally {
+        this.setOutputFormat(oldMode);
+    }
     return ret[1];
 };
 
@@ -7660,53 +7664,55 @@ CSL.Engine.prototype.processCitationCluster = function (citation, citationsPre, 
             ret = this.process_CitationCluster.call(this, citation.sortedItems, citation);
         } catch (e) {
             CSL.error("Error running CSL processor for preview: "+e);
-        }
-            
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** end run processor *********");
-            CSL.debug("****** start state restore *********");
-        }
-        //SNIP-END
-        // Wind out anything related to new items added for the preview.
-        // This means (1) names, (2) disambig state for affected items,
-        // (3) keys registered in the ambigs pool arrays, and (4) registry
-        // items.
-        //
+        } finally {
+            // Restore state even if an error occurred above
 
-        // restore sliced citations
-        this.registry.citationreg.citationByIndex = oldCitationList;
-        this.registry.citationreg.citationById = {};
-        for (var i = 0, ilen = oldCitationList.length; i < ilen; i += 1) {
-            this.registry.citationreg.citationById[oldCitationList[i].citationID] = oldCitationList[i];
-        }
-
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** start final update *********");
-        }
-        //SNIP-END
-        var oldItemIds = [];
-        for (var i = 0, ilen = oldItemList.length; i < ilen; i += 1) {
-            oldItemIds.push("" + oldItemList[i].id);
-        }
-        this.updateItems(oldItemIds, null, null, true);
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** end final update *********");
-        }
-        //SNIP-END
-        // Roll back disambig states
-        for (var key in oldAmbigs) {
-            if (oldAmbigs.hasOwnProperty(key)) {
-                this.registry.registry[key].disambig = oldAmbigs[key];
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** end run processor *********");
+                CSL.debug("****** start state restore *********");
             }
+            //SNIP-END
+            // Wind out anything related to new items added for the preview.
+            // This means (1) names, (2) disambig state for affected items,
+            // (3) keys registered in the ambigs pool arrays, and (4) registry
+            // items.
+            //
+
+            // restore sliced citations
+            this.registry.citationreg.citationByIndex = oldCitationList;
+            this.registry.citationreg.citationById = {};
+            for (var i = 0, ilen = oldCitationList.length; i < ilen; i += 1) {
+                this.registry.citationreg.citationById[oldCitationList[i].citationID] = oldCitationList[i];
+            }
+
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** start final update *********");
+            }
+            //SNIP-END
+            var oldItemIds = [];
+            for (var i = 0, ilen = oldItemList.length; i < ilen; i += 1) {
+                oldItemIds.push("" + oldItemList[i].id);
+            }
+            this.updateItems(oldItemIds, null, null, true);
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** end final update *********");
+            }
+            //SNIP-END
+            // Roll back disambig states
+            for (var key in oldAmbigs) {
+                if (oldAmbigs.hasOwnProperty(key)) {
+                    this.registry.registry[key].disambig = oldAmbigs[key];
+                }
+            }
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** end state restore *********");
+            }
+            //SNIP-END
         }
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** end state restore *********");
-        }
-        //SNIP-END
     } else {
         // Rerun cites that have moved across citations or had a change
         // in their number of subsequent references, so that disambiguate

--- a/src/api_cite.js
+++ b/src/api_cite.js
@@ -10,9 +10,13 @@ CSL.Engine.prototype.previewCitationCluster = function (citation, citationsPre, 
 	if (citation.citationID) {
 		delete citation.citationID;
 	}
-    var ret = this.processCitationCluster(citation, citationsPre, citationsPost, CSL.PREVIEW);
-
-    this.setOutputFormat(oldMode);
+    // Restore the output format even if the preview fails
+    var ret;
+    try {
+        ret = this.processCitationCluster(citation, citationsPre, citationsPost, CSL.PREVIEW);
+    } finally {
+        this.setOutputFormat(oldMode);
+    }
     return ret[1];
 };
 
@@ -728,53 +732,55 @@ CSL.Engine.prototype.processCitationCluster = function (citation, citationsPre, 
             ret = this.process_CitationCluster.call(this, citation.sortedItems, citation);
         } catch (e) {
             CSL.error("Error running CSL processor for preview: "+e);
-        }
-            
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** end run processor *********");
-            CSL.debug("****** start state restore *********");
-        }
-        //SNIP-END
-        // Wind out anything related to new items added for the preview.
-        // This means (1) names, (2) disambig state for affected items,
-        // (3) keys registered in the ambigs pool arrays, and (4) registry
-        // items.
-        //
+        } finally {
+            // Restore state even if an error occurred above
 
-        // restore sliced citations
-        this.registry.citationreg.citationByIndex = oldCitationList;
-        this.registry.citationreg.citationById = {};
-        for (var i = 0, ilen = oldCitationList.length; i < ilen; i += 1) {
-            this.registry.citationreg.citationById[oldCitationList[i].citationID] = oldCitationList[i];
-        }
-
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** start final update *********");
-        }
-        //SNIP-END
-        var oldItemIds = [];
-        for (var i = 0, ilen = oldItemList.length; i < ilen; i += 1) {
-            oldItemIds.push("" + oldItemList[i].id);
-        }
-        this.updateItems(oldItemIds, null, null, true);
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** end final update *********");
-        }
-        //SNIP-END
-        // Roll back disambig states
-        for (var key in oldAmbigs) {
-            if (oldAmbigs.hasOwnProperty(key)) {
-                this.registry.registry[key].disambig = oldAmbigs[key];
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** end run processor *********");
+                CSL.debug("****** start state restore *********");
             }
+            //SNIP-END
+            // Wind out anything related to new items added for the preview.
+            // This means (1) names, (2) disambig state for affected items,
+            // (3) keys registered in the ambigs pool arrays, and (4) registry
+            // items.
+            //
+
+            // restore sliced citations
+            this.registry.citationreg.citationByIndex = oldCitationList;
+            this.registry.citationreg.citationById = {};
+            for (var i = 0, ilen = oldCitationList.length; i < ilen; i += 1) {
+                this.registry.citationreg.citationById[oldCitationList[i].citationID] = oldCitationList[i];
+            }
+
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** start final update *********");
+            }
+            //SNIP-END
+            var oldItemIds = [];
+            for (var i = 0, ilen = oldItemList.length; i < ilen; i += 1) {
+                oldItemIds.push("" + oldItemList[i].id);
+            }
+            this.updateItems(oldItemIds, null, null, true);
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** end final update *********");
+            }
+            //SNIP-END
+            // Roll back disambig states
+            for (var key in oldAmbigs) {
+                if (oldAmbigs.hasOwnProperty(key)) {
+                    this.registry.registry[key].disambig = oldAmbigs[key];
+                }
+            }
+            //SNIP-START
+            if (this.debug) {
+                CSL.debug("****** end state restore *********");
+            }
+            //SNIP-END
         }
-        //SNIP-START
-        if (this.debug) {
-            CSL.debug("****** end state restore *********");
-        }
-        //SNIP-END
     } else {
         // Rerun cites that have moved across citations or had a change
         // in their number of subsequent references, so that disambiguate


### PR DESCRIPTION
previewCitationCluster() switches the processor's output format for the duration of the preview, but an error during processing skipped both the format restore and the registry state restore. A caller previewing in a format other than the processor's native one (e.g., an HTML preview on an RTF processor) was left with the processor generating output in the preview format for all subsequent processCitationCluster() calls, and with the preview citation still installed in the registry.

The output format is now restored no matter where in the preview the error occurs. The registry state restore covers errors thrown while rendering the cluster (the "Error running CSL processor for preview" rethrow); errors thrown earlier happen before the registry is modified. An error in the span in between -- the position bookkeeping, updateItems(), and sorting that run after the preview citations are installed in the registry -- would still skip the registry restore. Covering that span would mean wrapping several hundred lines shared with the non-preview path, so it's left alone here.

(This is causing https://forums.zotero.org/discussion/132539/markdown-appearing-in-citations for some people in Zotero due to the new preview pane in the citation dialog, which asks citeproc-js for an HTML version of the citation instead of the RTF version that gets inserted into the word processor.)