### PR TITLE
Ignore unknown style-level attributes

### DIFF
--- a/citeproc.js
+++ b/citeproc.js
@@ -4040,8 +4040,11 @@ CSL.Engine.prototype.setStyleAttributes = function () {
     attributes = this.cslXml.attributes(this.cslXml.dataObj);
     for (attrname in attributes) {
         if (attributes.hasOwnProperty(attrname)) {
-            // attr = attributes[key];
-            CSL.Attributes[attrname].call(dummy, this, attributes[attrname]);
+            if (CSL.Attributes[attrname]) {
+                CSL.Attributes[attrname].call(dummy, this, attributes[attrname]);
+            } else {
+                CSL.debug("warning: undefined attribute \"" + attrname + "\" in style");
+            }
         }
     }
 };

--- a/citeproc_commonjs.js
+++ b/citeproc_commonjs.js
@@ -4040,8 +4040,11 @@ CSL.Engine.prototype.setStyleAttributes = function () {
     attributes = this.cslXml.attributes(this.cslXml.dataObj);
     for (attrname in attributes) {
         if (attributes.hasOwnProperty(attrname)) {
-            // attr = attributes[key];
-            CSL.Attributes[attrname].call(dummy, this, attributes[attrname]);
+            if (CSL.Attributes[attrname]) {
+                CSL.Attributes[attrname].call(dummy, this, attributes[attrname]);
+            } else {
+                CSL.debug("warning: undefined attribute \"" + attrname + "\" in style");
+            }
         }
     }
 };

--- a/fixtures/local/citeprocjs_UnknownAttributes.txt
+++ b/fixtures/local/citeprocjs_UnknownAttributes.txt
@@ -1,0 +1,72 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== RESULT =====>>
+>>[0] Book Title, 2021
+<<===== RESULT =====<<
+
+
+>>===== CITATIONS =====>>
+[
+    [
+        {
+            "citationID": "CITATION-1",
+            "citationItems": [
+                {
+                    "id": "ITEM-1"
+                }
+            ],
+            "properties": {
+                "noteIndex": 1
+            }
+        },
+        [],
+        []
+    ]
+]
+<<===== CITATIONS =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0"
+      unknown-style-attribute="foo">
+  <info>
+    <id />
+    <title />
+    <updated>2026-07-30T00:00:00+00:00</updated>
+  </info>
+  <citation>
+    <layout delimiter="; ">
+      <group delimiter=", ">
+        <text variable="title" unknown-node-attribute="bar"/>
+        <date variable="issued" unknown-node-attribute="bar">
+          <date-part name="year"/>
+        </date>
+      </group>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "id": "ITEM-1",
+        "type": "book",
+        "title": "Book Title",
+        "issued": {
+            "date-parts": [
+                [
+                    2021
+                ]
+            ]
+        }
+    }
+]
+<<===== INPUT =====<<

--- a/src/build.js
+++ b/src/build.js
@@ -348,8 +348,11 @@ CSL.Engine.prototype.setStyleAttributes = function () {
     attributes = this.cslXml.attributes(this.cslXml.dataObj);
     for (attrname in attributes) {
         if (attributes.hasOwnProperty(attrname)) {
-            // attr = attributes[key];
-            CSL.Attributes[attrname].call(dummy, this, attributes[attrname]);
+            if (CSL.Attributes[attrname]) {
+                CSL.Attributes[attrname].call(dummy, this, attributes[attrname]);
+            } else {
+                CSL.debug("warning: undefined attribute \"" + attrname + "\" in style");
+            }
         }
     }
 };


### PR DESCRIPTION
Unknown attributes on nodes below cs:style are skipped with a console warning, but setStyleAttributes() dispatched to CSL.Attributes handlers without checking that a handler exists, so an unrecognized attribute on cs:style itself threw a TypeError during engine construction and the style failed to load entirely.

Skip unknown style-level attributes with the same warning used for node-level attributes. Unknown elements remain a hard error.

This allows additive style-level attributes to be adopted in future CSL versions without breaking deployed processors, in support of a proposed process for faster, more granular CSL specification updates [1].

[1] https://discourse.citationstyles.org/t/faster-csl-specification-updates/2050